### PR TITLE
Update tests for new ggplot2 release

### DIFF
--- a/tests/testthat/test-functions.R
+++ b/tests/testthat/test-functions.R
@@ -11,8 +11,11 @@ test_that("check-functions: scale_fill_map() returns a ggplot manual fill object
 
   output <- scale_fill_map(palette = "Kelly", num = 5)
 
-  expect_equal(output$scale_name, "manual")
-
+  expect_s3_class(output, "ScaleDiscrete")
+  expect_equal(
+    output$call,
+    quote(ggplot2::scale_fill_manual(values = mycolours, na.value = na.value))
+  )
 })
 
 #scale_color_map
@@ -20,7 +23,11 @@ test_that("check-functions: scale_color_map() returns a ggplot manual fill objec
 
   output <- scale_color_map(palette = "Kelly", num = 5)
 
-  expect_equal(output$scale_name, "manual")
+  expect_s3_class(output, "ScaleDiscrete")
+  expect_equal(
+    output$call,
+    quote(ggplot2::scale_color_manual(values = mycolours, na.value = na.value))
+  )
 
 })
 

--- a/tests/testthat/test-functions.R
+++ b/tests/testthat/test-functions.R
@@ -7,27 +7,21 @@ library(canadianmaps)    # load my package
 
 
 #scale_fill_map
-test_that("check-functions: scale_fill_map() returns a ggplot manual fill object", {
+test_that("check-functions: scale_fill_map() behaves like a ggplot manual fill object", {
 
   output <- scale_fill_map(palette = "Kelly", num = 5)
-
-  expect_s3_class(output, "ScaleDiscrete")
-  expect_equal(
-    output$call,
-    quote(ggplot2::scale_fill_manual(values = mycolours, na.value = na.value))
-  )
+  output$train(LETTERS[1:5])
+  values <- output$map(c(LETTERS[1:3], NA))
+  expect_equal(values, c("#B0DFE5", "#D9EEB4", "#FDB462", "grey90"))
 })
 
 #scale_color_map
-test_that("check-functions: scale_color_map() returns a ggplot manual fill object", {
+test_that("check-functions: scale_color_map() behaves like a ggplot manual fill object", {
 
   output <- scale_color_map(palette = "Kelly", num = 5)
-
-  expect_s3_class(output, "ScaleDiscrete")
-  expect_equal(
-    output$call,
-    quote(ggplot2::scale_color_manual(values = mycolours, na.value = na.value))
-  )
+  output$train(LETTERS[1:5])
+  values <- output$map(c(LETTERS[1:3], NA))
+  expect_equal(values, c("#B0DFE5", "#D9EEB4", "#FDB462", "grey90"))
 
 })
 


### PR DESCRIPTION
Hello there,

We have been preparing a new release of ggplot2 and during a reverse dependency check, it became apparent that the prospective ggplot2 3.5.0 would break canadianmaps.

This PR updates tests that were relying on a scale's `scale_name` property, which we've deprecated in ggplot2 3.5.0. Since manual scales aren't truly a class, but rather an interface to discrete scales, there isn't a direct tests if the output of `scale_fill/colour_map()` is a manual scale. Instead, I updated the test to expect that these scales function like manual scales.

To test the code changes with the release candidate, you can install it with the code below:

```r
remotes::install_github("tidyverse/ggplot2", ref = remotes::github_pull("5592"))
```

The release of ggplot2 3.5.0 is scheduled for the 12th of Februari. The progress of the release can be tracked in https://github.com/tidyverse/ggplot2/issues/5588. We hope that this PR might help canadianmaps get out a fix if necessary.